### PR TITLE
Fixing bug on notification view

### DIFF
--- a/app/src/main/java/com/appTec/RegistrateApp/interactor/NotificationInteractor.java
+++ b/app/src/main/java/com/appTec/RegistrateApp/interactor/NotificationInteractor.java
@@ -8,6 +8,8 @@ public interface NotificationInteractor {
 
 
     void getNotifications(); // Get the notifications from web service
-    void showNotifications(ArrayList<Notification> notifications); // To presenter
 
+
+
+    void detachJob();
 }

--- a/app/src/main/java/com/appTec/RegistrateApp/interactor/NotificationInteractorImpl.java
+++ b/app/src/main/java/com/appTec/RegistrateApp/interactor/NotificationInteractorImpl.java
@@ -15,24 +15,25 @@ import retrofit2.Response;
 
 public class NotificationInteractorImpl implements NotificationInteractor {
     /*
-    * This class will get for the presenter all the data requested
-    * */
+     * This class will get for the presenter all the data requested
+     * */
 
     // Attributes
     private NotificationPresenterImpl notificationPresenter;
+    private boolean canceled;
 
     public NotificationInteractorImpl(NotificationPresenterImpl notificationPresenter) {
         /*
-        * Constructor
-        * */
+         * Constructor
+         * */
         this.notificationPresenter = notificationPresenter;
     }
 
     @Override
     public void getNotifications() {
         /*
-        * Here goes the interaction with the source of data. In this case the source is a web service
-        * */
+         * Here goes the interaction with the source of data. In this case the source is a web service
+         * */
         NotificationsRetrofitInterface notificationsRetrofitInterface = ApiClient.getClient().create(NotificationsRetrofitInterface.class);
         Call<JsonObject> notificationCall = notificationsRetrofitInterface.get(ApiClient.getToken());
 
@@ -42,23 +43,25 @@ public class NotificationInteractorImpl implements NotificationInteractor {
 
                 ArrayList<Notification> notificationsResult = new ArrayList<Notification>();        // Result array that will be sent to the Presenter
 
-                JsonArray notificationListJson = response.body().getAsJsonArray("data");
+                JsonArray notificationListJson = new JsonArray(); //response.body().getAsJsonArray("data");
 
                 if (notificationListJson.size() == 0) {
                     /*
-                    * Todo
-                    * */
-
+                     * Todo
+                     * */
+                    notificationPresenter.showNotNewNotificationsMessage();
                 } else {
                     /*
-                    * Parse the data into notifications objects
-                    * */
+                     * Parse the data into notifications objects
+                     * */
+
+
                     for (int i = 0; i < notificationListJson.size(); i++) {
 
 
                         JsonObject notificationJson = notificationListJson.get(i).getAsJsonObject();
 
-                          // Todo: Parse the data
+                        // Todo: Parse the data
 //                        String title = notificationJson.get("title").getAsString();
 //                        String sentDate = notificationJson.get("sentDate").getAsString();
 //
@@ -70,11 +73,12 @@ public class NotificationInteractorImpl implements NotificationInteractor {
                     }
 
                     // Sent the result array to the Presenter
-                    showNotifications(notificationsResult);
+                    if (!canceled) {
+                        notificationPresenter.showNotifications(notificationsResult);
+                    } else {
+                        notificationCall.cancel();
+                    }
                 }
-
-
-
 
 
             }
@@ -82,8 +86,11 @@ public class NotificationInteractorImpl implements NotificationInteractor {
             @Override
             public void onFailure(Call<JsonObject> call, Throwable t) {
                 /*
-                * Todo
-                * */
+                 * Todo
+                 * */
+                if (notificationCall != null) {
+                    notificationCall.cancel();
+                }
             }
         });
 
@@ -91,8 +98,9 @@ public class NotificationInteractorImpl implements NotificationInteractor {
     }
 
     @Override
-    public void showNotifications(ArrayList<Notification> notifications) {
-        notificationPresenter.showNotifications(notifications);
+    public void detachJob() {
+        canceled = true;
+        notificationPresenter = null;
     }
 
 

--- a/app/src/main/java/com/appTec/RegistrateApp/presenter/NotificationPresenter.java
+++ b/app/src/main/java/com/appTec/RegistrateApp/presenter/NotificationPresenter.java
@@ -1,7 +1,5 @@
 package com.appTec.RegistrateApp.presenter;
 
-import android.view.View;
-
 import com.appTec.RegistrateApp.models.Notification;
 
 import java.util.ArrayList;
@@ -10,6 +8,11 @@ public interface NotificationPresenter {
 
     void getNotifications(); // To interactor
     void showNotifications(ArrayList<Notification> notifications); // To view
+    void showNotNewNotificationsMessage();
 
+
+
+    void detachView();
+    void detachJob();
 
 }

--- a/app/src/main/java/com/appTec/RegistrateApp/presenter/NotificationPresenterImpl.java
+++ b/app/src/main/java/com/appTec/RegistrateApp/presenter/NotificationPresenterImpl.java
@@ -41,7 +41,29 @@ public class NotificationPresenterImpl implements NotificationPresenter{
         /*
         * Calling the view
         * */
-        notificationView.showNotifications(notifications);
+        if(notificationView!=null) {
+            notificationView.showNotifications(notifications);
+        }
+    }
 
+    @Override
+    public void showNotNewNotificationsMessage() {
+        /**
+         * Calling the view
+         */
+        if(notificationView!=null) {
+        notificationView.showNotNewNotificationsMessage();}
+    }
+
+    @Override
+    public void detachView() {
+        if(notificationView!=null) {
+        notificationView = null;}
+    }
+
+    @Override
+    public void detachJob() {
+        notificationInteractor.detachJob();
+        notificationInteractor = null;
     }
 }

--- a/app/src/main/java/com/appTec/RegistrateApp/view/BottomNavigation.java
+++ b/app/src/main/java/com/appTec/RegistrateApp/view/BottomNavigation.java
@@ -23,6 +23,7 @@ import com.appTec.RegistrateApp.models.Device;
 import com.appTec.RegistrateApp.models.Permission;
 import com.appTec.RegistrateApp.models.PermissionType;
 import com.appTec.RegistrateApp.models.User;
+import com.appTec.RegistrateApp.presenter.HomePresenterImpl;
 import com.appTec.RegistrateApp.repository.geofence.GeofenceBroadcastReceiver;
 import com.appTec.RegistrateApp.repository.geofence.GeofenceConstants;
 import com.appTec.RegistrateApp.repository.geofence.GeofenceErrorMessages;
@@ -115,6 +116,8 @@ public class BottomNavigation extends AppCompatActivity implements
         Intent i = getIntent();
         Bundle bundle = i.getExtras();
         user = (User) bundle.getSerializable("user");
+
+
 
         //Hay casos en los quedevice puede venir en null!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! bug
         device = (Device) bundle.getSerializable("device");

--- a/app/src/main/java/com/appTec/RegistrateApp/view/activities/bottomNavigationUi/notifications/NotificationView.java
+++ b/app/src/main/java/com/appTec/RegistrateApp/view/activities/bottomNavigationUi/notifications/NotificationView.java
@@ -10,8 +10,12 @@ public interface NotificationView {
     * */
 
 
-    void getNotifications(); // Presenter
+
     void showNotifications(ArrayList<Notification> notifications);
+    void showNotNewNotificationsMessage();
 
-
+    void showAssistanceProgressDialog(String string);
+    void hideAssistanceProgressDialog();
+    void showConnectionErrorMessage();
+    void showDialog(String title, String message);
 }

--- a/app/src/main/java/com/appTec/RegistrateApp/view/activities/bottomNavigationUi/notifications/NotificationsFragment.java
+++ b/app/src/main/java/com/appTec/RegistrateApp/view/activities/bottomNavigationUi/notifications/NotificationsFragment.java
@@ -1,11 +1,15 @@
 package com.appTec.RegistrateApp.view.activities.bottomNavigationUi.notifications;
 
+import android.app.AlertDialog;
+import android.app.ProgressDialog;
 import android.content.Context;
+import android.content.DialogInterface;
 import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ListView;
+import android.widget.TextView;
 
 import androidx.annotation.NonNull;
 import androidx.fragment.app.Fragment;
@@ -22,6 +26,8 @@ public class NotificationsFragment extends Fragment implements NotificationView 
 
     //UI elements
     private ListView notificationsListVIew;
+    private TextView notificationTextView;
+    ProgressDialog progressDialog;
 
 
     // ? Presenter instance here. Not sure if this is the best way.
@@ -35,9 +41,6 @@ public class NotificationsFragment extends Fragment implements NotificationView 
         Bundle bundle = this.getArguments();
 
 
-        notificationsListVIew = fragmentDeviceView.findViewById(R.id.notification_list_view);
-
-
         // Attached the presenter
         notificationPresenter = new NotificationPresenterImpl(this);
 
@@ -45,9 +48,14 @@ public class NotificationsFragment extends Fragment implements NotificationView 
         notificationPresenter.getNotifications();
 
 
+
+        // Linking UI elements
+        progressDialog = new ProgressDialog(getContext());
+        notificationsListVIew = fragmentDeviceView.findViewById(R.id.notification_list_view);
+        notificationTextView = fragmentDeviceView.findViewById(R.id.notification_text_view);
+
         return fragmentDeviceView;
     }
-
 
 
     @Override
@@ -57,17 +65,64 @@ public class NotificationsFragment extends Fragment implements NotificationView 
     }
 
 
-    @Override
-    public void getNotifications() {
-        // Call to presenter
-        notificationPresenter.getNotifications();
-    }
+
 
     @Override
     public void showNotifications(ArrayList<Notification> notifications) {
         /*
-        * Show notifications on screen
-        * */
+         * Show notifications on screen
+         * */
         notificationsListVIew.setAdapter(new NotificationsListAdapter(getContext(), notifications));
+    }
+
+    //Dialogs
+    @Override
+    public void showAssistanceProgressDialog(String message) {
+        progressDialog.setMessage(message);
+        progressDialog.getWindow().setLayout(ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT);
+        progressDialog.show();
+        progressDialog.setCanceledOnTouchOutside(false);
+    }
+
+    @Override
+    public void hideAssistanceProgressDialog() {
+        progressDialog.dismiss();
+    }
+
+    @Override
+    public void showConnectionErrorMessage() {
+        showDialog("Error de conexión", "Al parecer no hay conexión a Internet.");
+    }
+
+    @Override
+    public void showDialog(String title, String message) {
+        AlertDialog alertDialog = new AlertDialog.Builder(getContext())
+                .setTitle(title)
+                .setMessage(message)
+                .setPositiveButton(android.R.string.yes, new DialogInterface.OnClickListener() {
+                    public void onClick(DialogInterface dialog, int which) {
+
+                    }
+                })
+                .setIcon(android.R.drawable.ic_dialog_alert)
+                .show();
+
+        alertDialog.getButton(AlertDialog.BUTTON_NEGATIVE).setEnabled(false);
+        alertDialog.show();
+    }
+
+    @Override
+    public void showNotNewNotificationsMessage() {
+        if(notificationTextView != null){
+            notificationTextView.setVisibility(View.VISIBLE);
+        }
+
+    }
+
+    @Override
+    public void onDestroyView() {
+        super.onDestroyView();
+        notificationPresenter.detachView();
+        notificationPresenter.detachJob();
     }
 }

--- a/app/src/main/res/layout/notifications_fragment_notification.xml
+++ b/app/src/main/res/layout/notifications_fragment_notification.xml
@@ -13,6 +13,12 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"/>
 
-
+    <TextView
+        android:id="@+id/notification_text_view"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_centerVertical="true"
+        android:visibility="gone"
+        ></TextView>
 
 </RelativeLayout>


### PR DESCRIPTION
The problem was that the presenter is instanced inside the Fragment. So it lives as same the Fragment. When the fragments destroy and the presenter made an async task, the asyn task probably will be trying to show the result on a fragment that does not exist anymore.

So i override the onDestroyView of the fragment to detach the pending request.

Fixed #22 